### PR TITLE
fix: Token group matches necessary token group interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,10 +2485,13 @@ version = "0.0.1-alpha"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "bytemuck",
  "cargo-husky",
+ "spl-discriminator",
  "spl-pod",
  "spl-tlv-account-resolution 0.4.0",
  "spl-transfer-hook-interface 0.5.0",
+ "spl-type-length-value",
  "wen_royalty_distribution",
 ]
 

--- a/programs/wen-new-standard/Cargo.toml
+++ b/programs/wen-new-standard/Cargo.toml
@@ -28,6 +28,10 @@ spl-transfer-hook-interface = { version = "0.5.0" }
 spl-tlv-account-resolution = "0.4.0"
 wen_royalty_distribution = { path = "../wen-royalty-distribution", features = ["cpi"] }
 
+spl-discriminator = { version = "0.1.0" }
+spl-type-length-value = { version = "0.3.0" }
+bytemuck = "1.14.0"
+
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = false # Disable features which are enabled by default

--- a/programs/wen-new-standard/src/state/group.rs
+++ b/programs/wen-new-standard/src/state/group.rs
@@ -1,10 +1,24 @@
 use anchor_lang::prelude::*;
+use bytemuck::{Pod, Zeroable};
+use spl_discriminator::SplDiscriminate;
 use spl_pod::error::PodSliceError;
+use spl_type_length_value::state::{TlvState, TlvStateBorrowed};
 
 use crate::MetadataErrors;
 
-/// Data struct for a `TokenGroup`
 #[account()]
+pub struct TokenGroupAccount {}
+
+impl TokenGroupAccount {
+    pub fn len() -> usize {
+        8 + TlvStateBorrowed::get_base_len() + std::mem::size_of::<TokenGroup>()
+    }
+}
+
+/// Data struct for a `TokenGroup`
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod, Zeroable, PartialEq, SplDiscriminate)]
+#[discriminator_hash_input("spl_token_group_interface:group")]
 pub struct TokenGroup {
     /// The authority that can sign to update the group
     pub update_authority: Pubkey,
@@ -18,8 +32,6 @@ pub struct TokenGroup {
 }
 
 impl TokenGroup {
-    pub const LEN: usize = 8 + 32 + 32 + 4 + 4;
-
     /// Creates a new `TokenGroup` state
     pub fn new(mint: &Pubkey, update_authority: Pubkey, max_size: u32) -> Self {
         Self {


### PR DESCRIPTION
Problem: Current account does not comply with token extension design.

Use TLV helpers to setup the account, keep the anchor account shell for convenience. Technically we could have more extensions in that one single account but i am not sure how far down the group has been used.

https://github.com/solana-labs/solana-program-library/tree/master/token-group/interface