### PR TITLE
Add manager account initialization

### DIFF
--- a/examples/src/programs/wen_new_standard.json
+++ b/examples/src/programs/wen_new_standard.json
@@ -3,6 +3,30 @@
   "name": "wen_new_standard",
   "instructions": [
     {
+      "name": "initManagerAccount",
+      "docs": [
+        "Init manager account"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "manager",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "createGroupAccount",
       "docs": [
         "create group"

--- a/examples/src/programs/wen_new_standard.ts
+++ b/examples/src/programs/wen_new_standard.ts
@@ -3,6 +3,30 @@ export type WenNewStandard = {
   "name": "wen_new_standard",
   "instructions": [
     {
+      "name": "initManagerAccount",
+      "docs": [
+        "Init manager account"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "manager",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "createGroupAccount",
       "docs": [
         "create group"
@@ -640,6 +664,30 @@ export const IDL: WenNewStandard = {
   "version": "0.0.1-alpha",
   "name": "wen_new_standard",
   "instructions": [
+    {
+      "name": "initManagerAccount",
+      "docs": [
+        "Init manager account"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "manager",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
     {
       "name": "createGroupAccount",
       "docs": [

--- a/programs/wen-new-standard/src/instructions/manager/init.rs
+++ b/programs/wen-new-standard/src/instructions/manager/init.rs
@@ -1,0 +1,23 @@
+use anchor_lang::prelude::*;
+
+use crate::{Manager, MANAGER_SEED};
+
+#[derive(Accounts)]
+#[instruction()]
+pub struct InitManagerAccount<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        init,
+        payer = payer,
+        seeds = [MANAGER_SEED],
+        space = Manager::LEN,
+        bump
+    )]
+    pub manager: Account<'info, Manager>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(_ctx: Context<InitManagerAccount>) -> Result<()> {
+    Ok(())
+}

--- a/programs/wen-new-standard/src/instructions/manager/init.rs
+++ b/programs/wen-new-standard/src/instructions/manager/init.rs
@@ -11,7 +11,7 @@ pub struct InitManagerAccount<'info> {
         init,
         payer = payer,
         seeds = [MANAGER_SEED],
-        space = Manager::LEN,
+        space = 8 + Manager::INIT_SPACE,
         bump
     )]
     pub manager: Account<'info, Manager>,

--- a/programs/wen-new-standard/src/instructions/manager/mod.rs
+++ b/programs/wen-new-standard/src/instructions/manager/mod.rs
@@ -1,0 +1,3 @@
+pub mod init;
+
+pub use init::*;

--- a/programs/wen-new-standard/src/instructions/mod.rs
+++ b/programs/wen-new-standard/src/instructions/mod.rs
@@ -1,7 +1,9 @@
 pub mod group;
+pub mod manager;
 pub mod mint;
 pub mod royalty;
 
 pub use group::*;
+pub use manager::*;
 pub use mint::*;
 pub use royalty::*;

--- a/programs/wen-new-standard/src/lib.rs
+++ b/programs/wen-new-standard/src/lib.rs
@@ -19,6 +19,14 @@ pub mod wen_new_standard {
     use super::*;
 
     /*
+        Manager instructions
+    */
+    /// Init manager account
+    pub fn init_manager_account(ctx: Context<InitManagerAccount>) -> Result<()> {
+        instructions::manager::init::handler(ctx)
+    }
+
+    /*
         Token group instructions
     */
     /// create group

--- a/programs/wen-new-standard/src/state/manager.rs
+++ b/programs/wen-new-standard/src/state/manager.rs
@@ -2,9 +2,9 @@ use anchor_lang::prelude::*;
 
 /// Data struct for a `Manager`
 #[account()]
+#[derive(InitSpace)]
 pub struct Manager {}
 impl Manager {
-    pub const LEN: usize = 8;
     /// Creates a new `Manager` state
     pub fn new() -> Self {
         Self {}


### PR DESCRIPTION
Done:
- Added instruction to initialize the manager account


Notes:
It is not necessary to initialize the manager account PDA.  However, due to the deserialization of `Account<'info, Manager>` it will expect the account to already be initialized. Alternatively you could simply specify `AccountInfo` without specifying the struct:
```
    #[account(
        seeds = [MANAGER_SEED],
        bump
    )]
    /// CHECK:
    pub manager: AccountInfo<'info>,
```