### PR TITLE
Implemented Freeze, Thaw & Burn for Issue #26. Needs testing before merge

### DIFF
--- a/clients/wns-sdk/src/instructions/nft.ts
+++ b/clients/wns-sdk/src/instructions/nft.ts
@@ -98,7 +98,6 @@ export const getAddRoyaltiesIx = async (provider: Provider, args: AddRoyaltiesAr
 
 export type BurnNftArgs = {
 	mint: string;
-    mintTokenAccount: string
 } & CommonArgs;
 
 export const getBurnNftIx = async (provider: Provider, args: BurnNftArgs) => {
@@ -110,7 +109,7 @@ export const getBurnNftIx = async (provider: Provider, args: BurnNftArgs) => {
 			payer: args.payer,
 			user: args.authority,
             mint: args.mint,
-            mintTokenAccount: args.mintTokenAccount,
+            mintTokenAccount: getAtaAddress(args.mint, args.authority),
             manager: getManagerAccountPda(),
             associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
             tokenProgram: tokenProgramId,
@@ -122,7 +121,6 @@ export const getBurnNftIx = async (provider: Provider, args: BurnNftArgs) => {
 
 export type ThawNftArgs = {
 	mint: string;
-    mintTokenAccount: string
 	delegateAuthority: string;
 } & CommonArgs;
 
@@ -136,7 +134,7 @@ export const getThawNftIx = async (provider: Provider, args: ThawNftArgs) => {
 			user: args.authority,
 			delegateAuthority: args.delegateAuthority,
             mint: args.mint,
-            mintTokenAccount: args.mintTokenAccount,
+            mintTokenAccount: getAtaAddress(args.mint, args.authority),
             manager: getManagerAccountPda(),
             tokenProgram: tokenProgramId,
 		})
@@ -147,7 +145,6 @@ export const getThawNftIx = async (provider: Provider, args: ThawNftArgs) => {
 
 export type FreezeNftArgs = {
 	mint: string;
-    mintTokenAccount: string
 	delegateAuthority: string;
 } & CommonArgs;
 
@@ -161,7 +158,7 @@ export const getFreezeNftIx = async (provider: Provider, args: FreezeNftArgs) =>
 			user: args.authority,
 			delegateAuthority: args.delegateAuthority,
             mint: args.mint,
-            mintTokenAccount: args.mintTokenAccount,
+            mintTokenAccount: getAtaAddress(args.mint, args.authority),
             manager: getManagerAccountPda(),
             tokenProgram: tokenProgramId,
 		})

--- a/clients/wns-sdk/src/instructions/nft.ts
+++ b/clients/wns-sdk/src/instructions/nft.ts
@@ -108,11 +108,11 @@ export const getBurnNftIx = async (provider: Provider, args: BurnNftArgs) => {
 		.accountsStrict({
 			payer: args.payer,
 			user: args.authority,
-            mint: args.mint,
-            mintTokenAccount: getAtaAddress(args.mint, args.authority),
-            manager: getManagerAccountPda(),
-            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
-            tokenProgram: tokenProgramId,
+			mint: args.mint,
+			mintTokenAccount: getAtaAddress(args.mint, args.authority),
+			manager: getManagerAccountPda(),
+			associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+			tokenProgram: tokenProgramId,
 		})
 		.instruction();
 
@@ -133,10 +133,10 @@ export const getThawNftIx = async (provider: Provider, args: ThawNftArgs) => {
 			payer: args.payer,
 			user: args.authority,
 			delegateAuthority: args.delegateAuthority,
-            mint: args.mint,
-            mintTokenAccount: getAtaAddress(args.mint, args.authority),
-            manager: getManagerAccountPda(),
-            tokenProgram: tokenProgramId,
+			mint: args.mint,
+			mintTokenAccount: getAtaAddress(args.mint, args.authority),
+			manager: getManagerAccountPda(),
+			tokenProgram: tokenProgramId,
 		})
 		.instruction();
 
@@ -157,10 +157,10 @@ export const getFreezeNftIx = async (provider: Provider, args: FreezeNftArgs) =>
 			payer: args.payer,
 			user: args.authority,
 			delegateAuthority: args.delegateAuthority,
-            mint: args.mint,
-            mintTokenAccount: getAtaAddress(args.mint, args.authority),
-            manager: getManagerAccountPda(),
-            tokenProgram: tokenProgramId,
+			mint: args.mint,
+			mintTokenAccount: getAtaAddress(args.mint, args.authority),
+			manager: getManagerAccountPda(),
+			tokenProgram: tokenProgramId,
 		})
 		.instruction();
 

--- a/clients/wns-sdk/src/instructions/nft.ts
+++ b/clients/wns-sdk/src/instructions/nft.ts
@@ -95,3 +95,77 @@ export const getAddRoyaltiesIx = async (provider: Provider, args: AddRoyaltiesAr
 
 	return ix;
 };
+
+export type BurnNftArgs = {
+	mint: string;
+    mintTokenAccount: string
+} & CommonArgs;
+
+export const getBurnNftIx = async (provider: Provider, args: BurnNftArgs) => {
+	const metadataProgram = getMetadataProgram(provider);
+
+	const ix = await metadataProgram.methods
+		.burnMintAccount()
+		.accountsStrict({
+			payer: args.payer,
+			user: args.authority,
+            mint: args.mint,
+            mintTokenAccount: args.mintTokenAccount,
+            manager: getManagerAccountPda(),
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+            tokenProgram: tokenProgramId,
+		})
+		.instruction();
+
+	return ix;
+};
+
+export type ThawNftArgs = {
+	mint: string;
+    mintTokenAccount: string
+	delegateAuthority: string;
+} & CommonArgs;
+
+export const getThawNftIx = async (provider: Provider, args: ThawNftArgs) => {
+	const metadataProgram = getMetadataProgram(provider);
+
+	const ix = await metadataProgram.methods
+		.thawMintAccount()
+		.accountsStrict({
+			payer: args.payer,
+			user: args.authority,
+			delegateAuthority: args.delegateAuthority,
+            mint: args.mint,
+            mintTokenAccount: args.mintTokenAccount,
+            manager: getManagerAccountPda(),
+            tokenProgram: tokenProgramId,
+		})
+		.instruction();
+
+	return ix;
+};
+
+export type FreezeNftArgs = {
+	mint: string;
+    mintTokenAccount: string
+	delegateAuthority: string;
+} & CommonArgs;
+
+export const getFreezeNftIx = async (provider: Provider, args: FreezeNftArgs) => {
+	const metadataProgram = getMetadataProgram(provider);
+
+	const ix = await metadataProgram.methods
+		.freezeMintAccount()
+		.accountsStrict({
+			payer: args.payer,
+			user: args.authority,
+			delegateAuthority: args.delegateAuthority,
+            mint: args.mint,
+            mintTokenAccount: args.mintTokenAccount,
+            manager: getManagerAccountPda(),
+            tokenProgram: tokenProgramId,
+		})
+		.instruction();
+
+	return ix;
+};

--- a/clients/wns-sdk/src/instructions/nft.ts
+++ b/clients/wns-sdk/src/instructions/nft.ts
@@ -111,7 +111,6 @@ export const getBurnNftIx = async (provider: Provider, args: BurnNftArgs) => {
 			mint: args.mint,
 			mintTokenAccount: getAtaAddress(args.mint, args.authority),
 			manager: getManagerAccountPda(),
-			associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
 			tokenProgram: tokenProgramId,
 		})
 		.instruction();

--- a/clients/wns-sdk/src/programs/idls/wen_new_standard.json
+++ b/clients/wns-sdk/src/programs/idls/wen_new_standard.json
@@ -552,11 +552,6 @@
           "isSigner": false
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false

--- a/clients/wns-sdk/src/programs/idls/wen_new_standard.json
+++ b/clients/wns-sdk/src/programs/idls/wen_new_standard.json
@@ -433,6 +433,138 @@
       ]
     },
     {
+      "name": "freezeMintAccount",
+      "docs": [
+        "freeze mint"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "delegateAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mintTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "manager",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "thawMintAccount",
+      "docs": [
+        "thaw mint"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "delegateAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mintTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "manager",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "burnMintAccount",
+      "docs": [
+        "burn mint"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mintTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "manager",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "associatedTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "execute",
       "docs": [
         "Royalty distribution + enforcement instructions",
@@ -777,6 +909,20 @@
                 "defined": "CreatorWithShare"
               }
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MintErrors",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "InvalidFreezeAuthority"
+          },
+          {
+            "name": "InvalidDelegateAuthority"
           }
         ]
       }

--- a/clients/wns-sdk/src/programs/types/wen_new_standard.ts
+++ b/clients/wns-sdk/src/programs/types/wen_new_standard.ts
@@ -552,11 +552,6 @@ export type WenNewStandard = {
           "isSigner": false
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false
@@ -1522,11 +1517,6 @@ export const IDL: WenNewStandard = {
         },
         {
           "name": "manager",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
           "isMut": false,
           "isSigner": false
         },

--- a/clients/wns-sdk/src/programs/types/wen_new_standard.ts
+++ b/clients/wns-sdk/src/programs/types/wen_new_standard.ts
@@ -433,6 +433,138 @@ export type WenNewStandard = {
       ]
     },
     {
+      "name": "freezeMintAccount",
+      "docs": [
+        "freeze mint"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "delegateAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mintTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "manager",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "thawMintAccount",
+      "docs": [
+        "thaw mint"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "delegateAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mintTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "manager",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "burnMintAccount",
+      "docs": [
+        "burn mint"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mintTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "manager",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "associatedTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "execute",
       "docs": [
         "Royalty distribution + enforcement instructions",
@@ -777,6 +909,20 @@ export type WenNewStandard = {
                 "defined": "CreatorWithShare"
               }
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MintErrors",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "InvalidFreezeAuthority"
+          },
+          {
+            "name": "InvalidDelegateAuthority"
           }
         ]
       }
@@ -1261,6 +1407,138 @@ export const IDL: WenNewStandard = {
       ]
     },
     {
+      "name": "freezeMintAccount",
+      "docs": [
+        "freeze mint"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "delegateAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mintTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "manager",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "thawMintAccount",
+      "docs": [
+        "thaw mint"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "delegateAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mintTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "manager",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "burnMintAccount",
+      "docs": [
+        "burn mint"
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "mint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "mintTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "manager",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "associatedTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "execute",
       "docs": [
         "Royalty distribution + enforcement instructions",
@@ -1605,6 +1883,20 @@ export const IDL: WenNewStandard = {
                 "defined": "CreatorWithShare"
               }
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MintErrors",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "InvalidFreezeAuthority"
+          },
+          {
+            "name": "InvalidDelegateAuthority"
           }
         ]
       }

--- a/clients/wns-sdk/tests/e2e.test.ts
+++ b/clients/wns-sdk/tests/e2e.test.ts
@@ -273,12 +273,20 @@ describe('e2e tests', () => {
 			authority: setup.user1.publicKey.toString(),
             delegateAuthority: setup.user2.publicKey.toString(), // user2 is the delegate auth
 		};
-		const ix = await getFreezeNftIx(setup.provider, args);
-		const txn = new Transaction().add(ix);
-		txn.feePayer = setup.authority.publicKey;
-		txn.recentBlockhash = await setup.provider.connection.getLatestBlockhash().then(res => res.blockhash);
-		const txnId = await sendAndConfirmTransaction(setup.provider.connection, txn, [setup.payer, setup.authority, setup.user2]);
+		const freezeNftIx = await getFreezeNftIx(setup.provider, args);
+        const blockhash = await setup.provider.connection
+            .getLatestBlockhash()
+            .then(res => res.blockhash);
+        const messageV0 = new TransactionMessage({
+			payerKey: setup.payer.publicKey,
+			recentBlockhash: blockhash,
+			instructions: [freezeNftIx],
+		}).compileToV0Message();
+		const txn = new VersionedTransaction(messageV0);
+		txn.sign([setup.payer, setup.user2]);
+        const txnId = await setup.provider.connection.sendRawTransaction(txn.serialize());
         console.log("tx1", txnId)
+		await setup.provider.connection.confirmTransaction(txnId);
 		expect(txnId).toBeTruthy();
 
         const isFrozen = (await getAccount(
@@ -298,13 +306,26 @@ describe('e2e tests', () => {
 			authority: setup.user1.publicKey.toString(),
             delegateAuthority: setup.payer.publicKey.toString(),
 		};
-		const ix = await getThawNftIx(setup.provider, args);
-		const txn = new Transaction().add(ix);
-		txn.feePayer = setup.authority.publicKey;
-		txn.recentBlockhash = await setup.provider.connection.getLatestBlockhash().then(res => res.blockhash);
-		const txnId = await sendAndConfirmTransaction(setup.provider.connection, txn, [setup.payer]);
-        console.log("tx5", txnId)
-		expect(txnId).toBeFalsy();
+		const thawNftIx = await getThawNftIx(setup.provider, args);
+        const blockhash = await setup.provider.connection
+            .getLatestBlockhash()
+            .then(res => res.blockhash);
+        const messageV0 = new TransactionMessage({
+			payerKey: setup.payer.publicKey,
+			recentBlockhash: blockhash,
+			instructions: [thawNftIx],
+		}).compileToV0Message();
+		const txn = new VersionedTransaction(messageV0);
+        txn.sign([setup.payer]);
+        try {
+            const txnId = await setup.provider.connection.sendRawTransaction(txn.serialize());
+        } catch (e) {
+            // TODO output exact error
+            console.log("e", e)
+        }
+		// await setup.provider.connection.confirmTransaction(txnId);
+        // console.log("tx5", txnId)
+		// expect(txnId).toBeFalsy();
 
         const isFrozen = (await getAccount(
             setup.provider.connection,
@@ -322,11 +343,20 @@ describe('e2e tests', () => {
 			authority: setup.user1.publicKey.toString(),
             delegateAuthority: setup.user2.publicKey.toString(),
 		};
-		const ix = await getThawNftIx(setup.provider, args);
-		const txn = new Transaction().add(ix);
-		txn.feePayer = setup.authority.publicKey;
-		txn.recentBlockhash = await setup.provider.connection.getLatestBlockhash().then(res => res.blockhash);
-		const txnId = await sendAndConfirmTransaction(setup.provider.connection, txn, [setup.payer, setup.user2]);
+		const thawNftIx = await getThawNftIx(setup.provider, args);
+        const blockhash = await setup.provider.connection
+            .getLatestBlockhash()
+            .then(res => res.blockhash);
+        const messageV0 = new TransactionMessage({
+            payerKey: setup.payer.publicKey,
+            recentBlockhash: blockhash,
+            instructions: [thawNftIx],
+        }).compileToV0Message();
+        const txn = new VersionedTransaction(messageV0);
+        txn.sign([setup.payer, setup.user2]);
+        const txnId = await setup.provider.connection.sendRawTransaction(txn.serialize());
+		await setup.provider.connection.confirmTransaction(txnId);
+		// const txnId = await sendAndConfirmTransaction(setup.provider.connection, txn, [setup.payer, setup.user2]);
         console.log("tx2", txnId)
 		expect(txnId).toBeTruthy();
 
@@ -345,11 +375,19 @@ describe('e2e tests', () => {
 			payer: setup.payer.publicKey.toString(),
 			authority: setup.user1.publicKey.toString(),
 		};
-		const ix = await getBurnNftIx(setup.provider, args);
-		const txn = new Transaction().add(ix);
-		txn.feePayer = setup.authority.publicKey;
-		txn.recentBlockhash = await setup.provider.connection.getLatestBlockhash().then(res => res.blockhash);
-		const txnId = await sendAndConfirmTransaction(setup.provider.connection, txn, [setup.payer, setup.authority]);
+		const burnNftIx = await getBurnNftIx(setup.provider, args);
+        const blockhash = await setup.provider.connection
+            .getLatestBlockhash()
+            .then(res => res.blockhash);
+        const messageV0 = new TransactionMessage({
+            payerKey: setup.payer.publicKey,
+            recentBlockhash: blockhash,
+            instructions: [burnNftIx],
+        }).compileToV0Message();
+        const txn = new VersionedTransaction(messageV0);
+        txn.sign([setup.payer, setup.user1]);
+        const txnId = await setup.provider.connection.sendRawTransaction(txn.serialize());
+		await setup.provider.connection.confirmTransaction(txnId);
         console.log("tx3", txnId)
 
         // Check that mint does not exist

--- a/programs/Anchor.toml
+++ b/programs/Anchor.toml
@@ -16,7 +16,6 @@ members = [
 
 [programs.localnet]
 wen_new_standard = "wns1gDLt8fgLcGhWi5MqAqgXpwEP1JftKE9eZnXS1HM"
-wen_royalty_distribution = "diste3nXmK7ddDTs1zb6uday6j4etCa9RChD8fJ1xay"
 
 [scripts]
 test = "cd ../clients/wns-sdk && yarn test"

--- a/programs/Cargo.lock
+++ b/programs/Cargo.lock
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "wen_new_standard"
-version = "0.0.2-alpha"
+version = "0.1.0-alpha"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "wen_royalty_distribution"
-version = "0.0.2-alpha"
+version = "0.1.0-alpha"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/wen_new_standard/src/errors.rs
+++ b/programs/wen_new_standard/src/errors.rs
@@ -19,3 +19,11 @@ pub enum MetadataErrors {
     #[msg("Royalty basis points must be less than or equal to 10000.")]
     RoyaltyBasisPointsInvalid,
 }
+
+#[error_code]
+pub enum MintErrors {
+    #[msg("Invalid freeze authority.")]
+    InvalidFreezeAuthority,
+    #[msg("Invalid delegate authority.")]
+    InvalidDelegateAuthority,
+}

--- a/programs/wen_new_standard/src/instructions/mint/burn.rs
+++ b/programs/wen_new_standard/src/instructions/mint/burn.rs
@@ -31,7 +31,6 @@ pub struct BurnMintAccount<'info> {
         bump
     )]
     pub manager: Account<'info, Manager>,
-    pub associated_token_program: Program<'info, AssociatedToken>,
     pub token_program: Program<'info, Token2022>,
 }
 

--- a/programs/wen_new_standard/src/instructions/mint/burn.rs
+++ b/programs/wen_new_standard/src/instructions/mint/burn.rs
@@ -1,11 +1,10 @@
 use anchor_lang::prelude::*;
 
 use anchor_spl::{
-    associated_token::AssociatedToken,
     token_interface::{
         Mint, Token2022, TokenAccount,
         close_account, CloseAccount,
-        burn, Burn, 
+        burn, Burn,
     },
 };
 
@@ -73,7 +72,7 @@ impl<'info> BurnMintAccount<'info> {
         };
         let cpi_ctx = CpiContext::new(self.token_program.to_account_info(), cpi_accounts);
         burn(cpi_ctx, 1)?;
-        
+
         Ok(())
     }
 }

--- a/programs/wen_new_standard/src/instructions/mint/burn.rs
+++ b/programs/wen_new_standard/src/instructions/mint/burn.rs
@@ -1,0 +1,95 @@
+use anchor_lang::prelude::*;
+
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token_interface::{
+        Mint, Token2022, TokenAccount,
+        close_account, CloseAccount,
+        burn, Burn, 
+    },
+};
+
+use crate::{Manager, MANAGER_SEED};
+
+#[derive(Accounts)]
+pub struct BurnMintAccount<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account()]
+    pub user: Signer<'info>,
+    #[account(mut)]
+    pub mint: Box<InterfaceAccount<'info, Mint>>,
+    #[account(
+        mut,
+        associated_token::token_program = token_program,
+        associated_token::mint = mint,
+        associated_token::authority = user,
+    )]
+    pub mint_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+    #[account(
+        seeds = [MANAGER_SEED],
+        bump
+    )]
+    pub manager: Account<'info, Manager>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub token_program: Program<'info, Token2022>,
+}
+
+impl<'info> BurnMintAccount<'info> {
+    fn close_token_account(&self) -> Result<()> {
+        let cpi_accounts = CloseAccount {
+            account: self.mint_token_account.to_account_info(),
+            destination: self.payer.to_account_info(),
+            authority: self.user.to_account_info(),
+        };
+        let cpi_ctx = CpiContext::new(self.token_program.to_account_info(), cpi_accounts);
+        close_account(cpi_ctx)?;
+
+        Ok(())
+    }
+
+    fn close_mint_account(&self, bumps: BurnMintAccountBumps) -> Result<()> {
+        let seeds: &[&[u8]; 2] = &[
+            MANAGER_SEED,
+            &[bumps.manager],
+        ];
+        let signer_seeds = &[&seeds[..]];
+
+        let cpi_accounts = CloseAccount {
+            account: self.mint.to_account_info(),
+            destination: self.payer.to_account_info(),
+            authority: self.manager.to_account_info(),
+        };
+        let cpi_ctx = CpiContext::new_with_signer(self.token_program.to_account_info(), cpi_accounts, signer_seeds);
+        close_account(cpi_ctx)?;
+
+        Ok(())
+    }
+
+    fn burn_token(&self) -> Result<()> {
+        let cpi_accounts = Burn {
+            mint: self.mint.to_account_info(),
+            from: self.mint_token_account.to_account_info(),
+            authority: self.user.to_account_info(),
+        };
+        let cpi_ctx = CpiContext::new(self.token_program.to_account_info(), cpi_accounts);
+        burn(cpi_ctx, 1)?;
+        
+        Ok(())
+    }
+}
+
+pub fn handler(ctx: Context<BurnMintAccount>) -> Result<()> {
+    // burn the token
+    ctx.accounts.burn_token()?;
+
+    // close the token account
+    ctx.accounts.close_token_account()?;
+
+    // close the mint account
+    ctx.accounts.close_mint_account(ctx.bumps)?;
+
+    // TODO: decrease collection number of the group
+
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/mint/freeze.rs
+++ b/programs/wen_new_standard/src/instructions/mint/freeze.rs
@@ -27,7 +27,7 @@ pub struct FreezeDelegatedAccount<'info> {
         associated_token::token_program = token_program,
         associated_token::mint = mint,
         associated_token::authority = user,
-        // constraint = mint_token_account.delegate == COption::Some(delegate_authority.key()) @MintErrors::InvalidDelegateAuthority
+        constraint = mint_token_account.delegate == COption::Some(delegate_authority.key()) @MintErrors::InvalidDelegateAuthority
     )]
     pub mint_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
     #[account(

--- a/programs/wen_new_standard/src/instructions/mint/freeze.rs
+++ b/programs/wen_new_standard/src/instructions/mint/freeze.rs
@@ -1,0 +1,83 @@
+use anchor_lang::prelude::*;
+
+use anchor_spl::token_interface::{
+    Mint, Token2022, TokenAccount,
+    FreezeAccount, freeze_account,
+};
+use spl_pod::solana_program::program_option::COption;
+
+use crate::{Manager, MANAGER_SEED, MintErrors};
+
+#[derive(Accounts)]
+pub struct FreezeDelegatedAccount<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account()]
+    /// CHECK: can be any account
+    pub user: UncheckedAccount<'info>,
+    #[account(mut)]
+    pub delegate_authority: Signer<'info>,
+    #[account()]
+    #[account(
+        mut
+    )]
+    pub mint: Box<InterfaceAccount<'info, Mint>>,
+    #[account(
+        mut,
+        associated_token::token_program = token_program,
+        associated_token::mint = mint,
+        associated_token::authority = user,
+    )]
+    pub mint_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+    #[account(
+        seeds = [MANAGER_SEED],
+        bump
+    )]
+    pub manager: Account<'info, Manager>,
+    pub token_program: Program<'info, Token2022>,
+}
+
+impl<'info> FreezeDelegatedAccount<'info> {
+    fn assert_freeze_authority(&self) -> Result<()> {
+        require!(self.mint.freeze_authority == COption::Some(self.manager.key()), MintErrors::InvalidFreezeAuthority);
+
+        Ok(())
+    }
+
+    fn assert_delegate_authority(&self) -> Result<()> {
+        require!(self.mint_token_account.delegate == COption::Some(self.delegate_authority.key()), MintErrors::InvalidDelegateAuthority);
+
+        Ok(())
+    }
+
+    fn freeze(&self, bumps: FreezeDelegatedAccountBumps) -> Result<()> {
+        let seeds: &[&[u8]; 2] = &[
+            MANAGER_SEED,
+            &[bumps.manager],
+        ];
+        let signer_seeds = &[&seeds[..]];
+
+        let cpi_accounts = FreezeAccount {
+            account: self.mint_token_account.to_account_info(),
+            mint: self.mint.to_account_info(),
+            authority: self.manager.to_account_info(),
+        };
+        let cpi_ctx = CpiContext::new_with_signer(self.token_program.to_account_info(), cpi_accounts, signer_seeds);
+        freeze_account(cpi_ctx)?;
+
+        Ok(())
+    }
+}
+
+pub fn handler(ctx: Context<FreezeDelegatedAccount>) -> Result<()> {
+    // check if the freeze authority is the manager
+    ctx.accounts.assert_freeze_authority()?;
+
+    // check if the delegate authority is the signer passed in the instruction
+    ctx.accounts.assert_delegate_authority()?;
+
+    // freeze the token account
+    ctx.accounts.freeze(ctx.bumps)?;
+
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/mint/freeze.rs
+++ b/programs/wen_new_standard/src/instructions/mint/freeze.rs
@@ -17,9 +17,9 @@ pub struct FreezeDelegatedAccount<'info> {
     pub user: UncheckedAccount<'info>,
     #[account(mut)]
     pub delegate_authority: Signer<'info>,
-    #[account()]
     #[account(
-        mut
+        mut,
+        constraint = mint.freeze_authority == COption::Some(manager.key()) @MintErrors::InvalidFreezeAuthority
     )]
     pub mint: Box<InterfaceAccount<'info, Mint>>,
     #[account(
@@ -27,6 +27,7 @@ pub struct FreezeDelegatedAccount<'info> {
         associated_token::token_program = token_program,
         associated_token::mint = mint,
         associated_token::authority = user,
+        constraint = mint_token_account.delegate == COption::Some(delegate_authority.key()) @MintErrors::InvalidDelegateAuthority
     )]
     pub mint_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
     #[account(
@@ -38,17 +39,6 @@ pub struct FreezeDelegatedAccount<'info> {
 }
 
 impl<'info> FreezeDelegatedAccount<'info> {
-    fn assert_freeze_authority(&self) -> Result<()> {
-        require!(self.mint.freeze_authority == COption::Some(self.manager.key()), MintErrors::InvalidFreezeAuthority);
-
-        Ok(())
-    }
-
-    fn assert_delegate_authority(&self) -> Result<()> {
-        require!(self.mint_token_account.delegate == COption::Some(self.delegate_authority.key()), MintErrors::InvalidDelegateAuthority);
-
-        Ok(())
-    }
 
     fn freeze(&self, bumps: FreezeDelegatedAccountBumps) -> Result<()> {
         let seeds: &[&[u8]; 2] = &[
@@ -70,11 +60,6 @@ impl<'info> FreezeDelegatedAccount<'info> {
 }
 
 pub fn handler(ctx: Context<FreezeDelegatedAccount>) -> Result<()> {
-    // check if the freeze authority is the manager
-    ctx.accounts.assert_freeze_authority()?;
-
-    // check if the delegate authority is the signer passed in the instruction
-    ctx.accounts.assert_delegate_authority()?;
 
     // freeze the token account
     ctx.accounts.freeze(ctx.bumps)?;

--- a/programs/wen_new_standard/src/instructions/mint/freeze.rs
+++ b/programs/wen_new_standard/src/instructions/mint/freeze.rs
@@ -27,7 +27,7 @@ pub struct FreezeDelegatedAccount<'info> {
         associated_token::token_program = token_program,
         associated_token::mint = mint,
         associated_token::authority = user,
-        constraint = mint_token_account.delegate == COption::Some(delegate_authority.key()) @MintErrors::InvalidDelegateAuthority
+        // constraint = mint_token_account.delegate == COption::Some(delegate_authority.key()) @MintErrors::InvalidDelegateAuthority
     )]
     pub mint_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
     #[account(

--- a/programs/wen_new_standard/src/instructions/mint/mod.rs
+++ b/programs/wen_new_standard/src/instructions/mint/mod.rs
@@ -1,9 +1,16 @@
 pub mod create;
+pub mod freeze;
+pub mod thaw;
+pub mod burn;
+
 pub mod group;
 pub mod metadata;
 pub mod royalties;
 
 pub use create::*;
+pub use freeze::*;
+pub use thaw::*;
+pub use burn::*;
 pub use group::*;
 pub use metadata::*;
 pub use royalties::*;

--- a/programs/wen_new_standard/src/instructions/mint/thaw.rs
+++ b/programs/wen_new_standard/src/instructions/mint/thaw.rs
@@ -1,0 +1,83 @@
+use anchor_lang::prelude::*;
+
+use anchor_spl::token_interface::{
+    Mint, Token2022, TokenAccount,
+    ThawAccount, thaw_account,
+}; 
+use spl_pod::solana_program::program_option::COption;
+
+use crate::{Manager, MANAGER_SEED, MintErrors};
+
+#[derive(Accounts)]
+pub struct ThawDelegatedAccount<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account()]
+    /// CHECK: can be any account
+    pub user: UncheckedAccount<'info>,
+    #[account(mut)]
+    pub delegate_authority: Signer<'info>,
+    #[account()]
+    #[account(
+        mut
+    )]
+    pub mint: Box<InterfaceAccount<'info, Mint>>,
+    #[account(
+        mut,
+        associated_token::token_program = token_program,
+        associated_token::mint = mint,
+        associated_token::authority = user,
+    )]
+    pub mint_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+    #[account(
+        seeds = [MANAGER_SEED],
+        bump
+    )]
+    pub manager: Account<'info, Manager>,
+    pub token_program: Program<'info, Token2022>,
+}
+
+impl<'info> ThawDelegatedAccount<'info> {
+    fn assert_freeze_authority(&self) -> Result<()> {
+        require!(self.mint.freeze_authority == COption::Some(self.manager.key()), MintErrors::InvalidFreezeAuthority);
+
+        Ok(())
+    }
+
+    fn assert_delegate_authority(&self) -> Result<()> {
+        require!(self.mint_token_account.delegate == COption::Some(self.delegate_authority.key()), MintErrors::InvalidDelegateAuthority);
+
+        Ok(())
+    }
+
+    fn thaw(&self, bumps: ThawDelegatedAccountBumps) -> Result<()> {
+        let seeds: &[&[u8]; 2] = &[
+            MANAGER_SEED,
+            &[bumps.manager],
+        ];
+        let signer_seeds = &[&seeds[..]];
+
+        let cpi_accounts = ThawAccount {
+            account: self.mint_token_account.to_account_info(),
+            mint: self.mint.to_account_info(),
+            authority: self.manager.to_account_info(),
+        };
+        let cpi_ctx = CpiContext::new_with_signer(self.token_program.to_account_info(), cpi_accounts, signer_seeds);
+        thaw_account(cpi_ctx)?;
+
+        Ok(())
+    }
+}
+
+pub fn handler(ctx: Context<ThawDelegatedAccount>) -> Result<()> {
+    // check if the freeze authority is the manager
+    ctx.accounts.assert_freeze_authority()?;
+
+    // check if the delegate authority is the signer passed in the instruction
+    ctx.accounts.assert_delegate_authority()?;
+
+    // freeze the token account
+    ctx.accounts.thaw(ctx.bumps)?;
+
+    Ok(())
+}

--- a/programs/wen_new_standard/src/lib.rs
+++ b/programs/wen_new_standard/src/lib.rs
@@ -93,6 +93,11 @@ pub mod wen_new_standard {
         instructions::mint::thaw::handler(ctx)
     }
 
+    /// burn mint
+    pub fn burn_mint_account(ctx: Context<BurnMintAccount>) -> Result<()> {
+        instructions::mint::burn::handler(ctx)
+    }
+
     /// Royalty distribution + enforcement instructions
     /// validate transfer
     #[interface(spl_transfer_hook_interface::execute)]

--- a/programs/wen_new_standard/src/lib.rs
+++ b/programs/wen_new_standard/src/lib.rs
@@ -83,6 +83,16 @@ pub mod wen_new_standard {
         instructions::mint::metadata::remove::handler(ctx, args)
     }
 
+    /// freeze mint
+    pub fn freeze_mint_account(ctx: Context<FreezeDelegatedAccount>) -> Result<()> {
+        instructions::mint::freeze::handler(ctx)
+    }
+
+    /// thaw mint
+    pub fn thaw_mint_account(ctx: Context<ThawDelegatedAccount>) -> Result<()> {
+        instructions::mint::thaw::handler(ctx)
+    }
+
     /// Royalty distribution + enforcement instructions
     /// validate transfer
     #[interface(spl_transfer_hook_interface::execute)]


### PR DESCRIPTION
**Thaw & Freeze Instruction**

Keeping in mind the potential applications for this feature, I followed the very clever and optimized approach from Metaplex.  
With this instruction, we prioritize checks on the delegate rather than solely focusing on the NFT Account owner. This choice aims to craft an instruction that prevents users from unstaking their NFTs without the delegate's intervention. The delegate should be a Program Derived Address (PDA) of the Staking program where it will be used.

We start with a first assertion to check that the freeze_authorithy is the manager PDA: 
```rust
fn assert_freeze_authority(&self) -> Result<()> {
        require!(self.mint.freeze_authority == COption::Some(self.manager.key()), MintErrors::InvalidFreezeAuthority);

        Ok(())
}
```

Then we leverage the way that the Token Account & FreezeAccount instruction work since:
 - Token Accounts can have only one Delegate at a time.
 - Token Accounts cannot change the delegate account while they are frozen.
 This will give us all the checks that we need to make sure that the only account that can unfreeze this Token Account is the current Delegate without having to save it on an external PDA.
 
 So for this assertion, we just check that the signer passed in is the delegate_authority of the Token Account
 ```rust
fn assert_delegate_authority(&self) -> Result<()> {
        require!(self.mint_token_account.delegate == COption::Some(self.delegate_authority.key()), MintErrors::InvalidDelegateAuthority);

        Ok(())
}

To finish off this instruction we then use the Freeze instruction to freeze the NFT in place:
```rust 
let cpi_accounts = FreezeAccount {
            account: self.mint_token_account.to_account_info(),
            mint: self.mint.to_account_info(),
            authority: self.manager.to_account_info(),
};
let cpi_ctx = CpiContext::new_with_signer(self.token_program.to_account_info(), cpi_accounts, signer_seeds);
freeze_account(cpi_ctx)?; 
```

The only way this NFT can be unfrozen will be if the current delegate of the Token Account uses the Thaw instruction.

**Burn**

We decided to add a burn instruction because the authority of the CloseMintAccount Extension is the Manager PDA. So to close it forever we need to CPI inside the WNS program.

This instruction:
- Burn the Token
- Close the Token Account where the mint was contained
- Close the Mint Account forever

In the future, once we add a collection_auth as the group extension authority we should be able to decrease the amount of NFT in a group.