### PR TITLE
fix ordering of name symbol uri

### DIFF
--- a/programs/wen_new_standard/src/instructions/mint/create.rs
+++ b/programs/wen_new_standard/src/instructions/mint/create.rs
@@ -71,8 +71,8 @@ impl<'info> CreateMintAccount<'info> {
     fn initialize_token_metadata(
         &self,
         name: String,
-        uri: String,
         symbol: String,
+        uri: String,
     ) -> ProgramResult {
         let cpi_accounts = TokenMetadataInitialize {
             token_program_id: self.token_program.to_account_info(),


### PR DESCRIPTION
ordering of tokenmetadata was: name, uri, symbol

changed to: name, symbol, uri