### PR TITLE
Remove `close_token_account` from mint::burn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Wen New Standard
-Current Version: ```0.3.1-alpha```
+Current Version: ```0.3.2-alpha```
 
 The current WNS version shows the minting of a non-fungible token from the Token Extensions [(Token 2022)](https://spl.solana.com/token-2022) program. It restricts the decimals to 0 and the supply of the mint to 1. It also initializes core metadata of Name, Symbol, and Uri as apart of the token directly. There are no external metadata accounts or programs needed. Group and Member accounts are copies of the Solana Extensions and will be migrated to be within the mint account once they're released on mainnet. Royalties are implmented via the extra_metadata field in the Metadata account and distributed through the Wen Royalty Distribution Contract.
 

--- a/clients/wns-sdk/src/instructions/nft.ts
+++ b/clients/wns-sdk/src/instructions/nft.ts
@@ -110,7 +110,7 @@ export const getBurnNftIx = async (provider: Provider, args: BurnNftArgs) => {
 	const ix = await metadataProgram.methods
 		.burnMintAccount()
 		.accountsStrict({
-			payer: args.payer,
+			receiver: args.payer,
 			user: args.authority,
 			mint: args.mint,
 			mintTokenAccount: getAtaAddress(args.mint, args.authority),

--- a/clients/wns-sdk/src/programs/idls/wen_new_standard.json
+++ b/clients/wns-sdk/src/programs/idls/wen_new_standard.json
@@ -527,9 +527,9 @@
       ],
       "accounts": [
         {
-          "name": "payer",
+          "name": "receiver",
           "isMut": true,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "user",

--- a/clients/wns-sdk/src/programs/idls/wen_new_standard.json
+++ b/clients/wns-sdk/src/programs/idls/wen_new_standard.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.1-alpha",
+  "version": "0.3.2-alpha",
   "name": "wen_new_standard",
   "instructions": [
     {

--- a/clients/wns-sdk/src/programs/types/wen_new_standard.ts
+++ b/clients/wns-sdk/src/programs/types/wen_new_standard.ts
@@ -1,5 +1,5 @@
 export type WenNewStandard = {
-  "version": "0.3.1-alpha",
+  "version": "0.3.2-alpha",
   "name": "wen_new_standard",
   "instructions": [
     {
@@ -974,7 +974,7 @@ export type WenNewStandard = {
 };
 
 export const IDL: WenNewStandard = {
-  "version": "0.3.1-alpha",
+  "version": "0.3.2-alpha",
   "name": "wen_new_standard",
   "instructions": [
     {

--- a/clients/wns-sdk/src/programs/types/wen_new_standard.ts
+++ b/clients/wns-sdk/src/programs/types/wen_new_standard.ts
@@ -527,9 +527,9 @@ export type WenNewStandard = {
       ],
       "accounts": [
         {
-          "name": "payer",
+          "name": "receiver",
           "isMut": true,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "user",
@@ -1502,9 +1502,9 @@ export const IDL: WenNewStandard = {
       ],
       "accounts": [
         {
-          "name": "payer",
+          "name": "receiver",
           "isMut": true,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "user",

--- a/programs/wen_new_standard/Cargo.toml
+++ b/programs/wen_new_standard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wen_new_standard"
-version = "0.3.1-alpha"
+version = "0.3.2-alpha"
 description = "An open and composable NFT standard on Solana."
 edition = "2021"
 

--- a/programs/wen_new_standard/src/instructions/mint/burn.rs
+++ b/programs/wen_new_standard/src/instructions/mint/burn.rs
@@ -19,9 +19,8 @@ pub struct BurnMintAccount<'info> {
     pub mint: Box<InterfaceAccount<'info, Mint>>,
     #[account(
         mut,
-        associated_token::token_program = token_program,
-        associated_token::mint = mint,
-        associated_token::authority = user,
+        token::mint = mint.key(),
+        token::token_program = token_program.key(),
     )]
     pub mint_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
     #[account(

--- a/programs/wen_new_standard/src/instructions/mint/burn.rs
+++ b/programs/wen_new_standard/src/instructions/mint/burn.rs
@@ -1,11 +1,9 @@
 use anchor_lang::prelude::*;
 
-use anchor_spl::{
-    token_interface::{
-        Mint, Token2022, TokenAccount,
-        close_account, CloseAccount,
-        burn, Burn,
-    },
+use anchor_spl::token_interface::{
+    Mint, Token2022, TokenAccount,
+    close_account, CloseAccount,
+    burn, Burn,
 };
 
 use crate::{Manager, MANAGER_SEED};
@@ -13,7 +11,8 @@ use crate::{Manager, MANAGER_SEED};
 #[derive(Accounts)]
 pub struct BurnMintAccount<'info> {
     #[account(mut)]
-    pub payer: Signer<'info>,
+    /// CHECK: can be any account
+    pub receiver: UncheckedAccount<'info>,
     #[account()]
     pub user: Signer<'info>,
     #[account(mut)]
@@ -43,7 +42,7 @@ impl<'info> BurnMintAccount<'info> {
 
         let cpi_accounts = CloseAccount {
             account: self.mint.to_account_info(),
-            destination: self.payer.to_account_info(),
+            destination: self.receiver.to_account_info(),
             authority: self.manager.to_account_info(),
         };
         let cpi_ctx = CpiContext::new_with_signer(self.token_program.to_account_info(), cpi_accounts, signer_seeds);

--- a/programs/wen_new_standard/src/instructions/mint/burn.rs
+++ b/programs/wen_new_standard/src/instructions/mint/burn.rs
@@ -34,18 +34,6 @@ pub struct BurnMintAccount<'info> {
 }
 
 impl<'info> BurnMintAccount<'info> {
-    fn close_token_account(&self) -> Result<()> {
-        let cpi_accounts = CloseAccount {
-            account: self.mint_token_account.to_account_info(),
-            destination: self.payer.to_account_info(),
-            authority: self.user.to_account_info(),
-        };
-        let cpi_ctx = CpiContext::new(self.token_program.to_account_info(), cpi_accounts);
-        close_account(cpi_ctx)?;
-
-        Ok(())
-    }
-
     fn close_mint_account(&self, bumps: BurnMintAccountBumps) -> Result<()> {
         let seeds: &[&[u8]; 2] = &[
             MANAGER_SEED,
@@ -80,9 +68,6 @@ impl<'info> BurnMintAccount<'info> {
 pub fn handler(ctx: Context<BurnMintAccount>) -> Result<()> {
     // burn the token
     ctx.accounts.burn_token()?;
-
-    // close the token account
-    ctx.accounts.close_token_account()?;
 
     // close the mint account
     ctx.accounts.close_mint_account(ctx.bumps)?;


### PR DESCRIPTION
**Change 1**
The burn ix has too much responsibility. So I removed the functionality of `close_token_account`. The user can close this account on his/her own accord.

**Change 2**
Changes on the account constraints in the burn ix, from this:
```

    #[account(
        associated_token::token_program = token_program,
        associated_token::mint = mint,
        associated_token::authority = user,
    )]
    pub mint_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
```
to this 
```
    #[account(
        mut,
        token::mint = mint.key(),
        token::token_program = token_program.key(),
    )]
    pub mint_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
```

This has negligible impact as the authority checks happen in the T22 burn ix. 
Also with this change, the permanent delegate can now burn the token as well. 

**Change 3**
Change`payer` in the `burnMintAccount` context to be `receiver` and non-signer