### PR TITLE
Remove unnecessary auth check for execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Wen New Standard
-Current Version: ```0.3.1-alpha```
+Current Version: ```0.3.2-alpha```
 
 The current WNS version shows the minting of a non-fungible token from the Token Extensions [(Token 2022)](https://spl.solana.com/token-2022) program. It restricts the decimals to 0 and the supply of the mint to 1. It also initializes core metadata of Name, Symbol, and Uri as apart of the token directly. There are no external metadata accounts or programs needed. Group and Member accounts are copies of the Solana Extensions and will be migrated to be within the mint account once they're released on mainnet. Royalties are implmented via the extra_metadata field in the Metadata account and distributed through the Wen Royalty Distribution Contract.
 

--- a/clients/wns-sdk/src/programs/idls/wen_new_standard.json
+++ b/clients/wns-sdk/src/programs/idls/wen_new_standard.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.1-alpha",
+  "version": "0.3.2-alpha",
   "name": "wen_new_standard",
   "instructions": [
     {

--- a/clients/wns-sdk/src/programs/types/wen_new_standard.ts
+++ b/clients/wns-sdk/src/programs/types/wen_new_standard.ts
@@ -1,5 +1,5 @@
 export type WenNewStandard = {
-  "version": "0.3.1-alpha",
+  "version": "0.3.2-alpha",
   "name": "wen_new_standard",
   "instructions": [
     {
@@ -974,7 +974,7 @@ export type WenNewStandard = {
 };
 
 export const IDL: WenNewStandard = {
-  "version": "0.3.1-alpha",
+  "version": "0.3.2-alpha",
   "name": "wen_new_standard",
   "instructions": [
     {

--- a/programs/wen_new_standard/Cargo.toml
+++ b/programs/wen_new_standard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wen_new_standard"
-version = "0.3.1-alpha"
+version = "0.3.2-alpha"
 description = "An open and composable NFT standard on Solana."
 edition = "2021"
 

--- a/programs/wen_new_standard/src/instructions/royalty/execute.rs
+++ b/programs/wen_new_standard/src/instructions/royalty/execute.rs
@@ -8,7 +8,6 @@ use crate::{hook_in_cpi, ApproveAccount, MetadataErrors, META_LIST_ACCOUNT_SEED}
 pub struct ExecuteTransferHook<'info> {
     #[account(
         token::mint = mint,
-        token::authority = owner_delegate,
         token::token_program = anchor_spl::token_interface::spl_token_2022::id(),
     )]
     pub source_account: Box<InterfaceAccount<'info, TokenAccount>>,


### PR DESCRIPTION
I simply removed the auth check on the source ata in the execute ix
```
    #[account(
        token::mint = mint,
        token::authority = owner_delegate, // removed
        token::token_program = anchor_spl::token_interface::spl_token_2022::id(),
    )]
    pub source_account: Box<InterfaceAccount<'info, TokenAccount>>,
```

The auth is checked anyway in the outer transfer instruction. 

Keeping the auth check means we are unable to transfer the NFT using the permanent delegate.