### PR TITLE
Solved an Overflow Error for Rent transfer

### DIFF
--- a/programs/Cargo.lock
+++ b/programs/Cargo.lock
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "wen_new_standard"
-version = "0.1.0-alpha"
+version = "0.3.2-alpha"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "wen_royalty_distribution"
-version = "0.1.0-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/wen_new_standard/src/utils.rs
+++ b/programs/wen_new_standard/src/utils.rs
@@ -32,13 +32,14 @@ pub fn update_account_lamports_to_minimum_balance<'info>(
     payer: AccountInfo<'info>,
     system_program: AccountInfo<'info>,
 ) -> Result<()> {
-    let extra_lamports = Rent::get()?.minimum_balance(account.data_len()) - account.get_lamports();
-    if extra_lamports > 0 {
+    if Rent::get()?.minimum_balance(account.data_len()) > account.get_lamports() {
+        let extra_lamports = Rent::get()?.minimum_balance(account.data_len()) - account.get_lamports();
         invoke(
             &transfer(payer.key, account.key, extra_lamports),
             &[payer, account, system_program],
         )?;
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
The `update_account_lamports_to_minimum_balance` macro didn't account for the possibility of needing less space than what it was provided at the start causing an Overflow Error. 

The new `update_account_lamports_to_minimum_balance` account is for this but having a check first that verifies that the account Lamports amount is less than what is required.