### PR TITLE
chore: replace anchor extension attributes to avoid stack offset exceeds

### DIFF
--- a/programs/Cargo.lock
+++ b/programs/Cargo.lock
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "wen_new_standard"
-version = "0.1.0-alpha"
+version = "0.3.2-alpha"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "wen_royalty_distribution"
-version = "0.1.0-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/wen_new_standard/src/instructions/group/create.rs
+++ b/programs/wen_new_standard/src/instructions/group/create.rs
@@ -1,17 +1,30 @@
-use anchor_lang::{prelude::*, solana_program::entrypoint::ProgramResult};
-use anchor_spl::{
-    associated_token::AssociatedToken,
-    token_interface::{
-        mint_to, set_authority,
-        spl_token_2022::instruction::AuthorityType,
-        token_metadata_initialize, Mint, MintTo, SetAuthority, Token2022, TokenAccount,
-        TokenMetadataInitialize,
-    },
+use anchor_lang::{
+    prelude::*,
+    solana_program::entrypoint::ProgramResult,
+    system_program::{create_account, CreateAccount},
 };
 
+use anchor_spl::{
+    associated_token::{
+        create as create_associated_token, get_associated_token_address_with_program_id,
+        AssociatedToken, Create as CreateAssociatedToken,
+    },
+    token_2022::{
+        initialize_mint2, initialize_mint_close_authority, spl_token_2022::state::Mint,
+        InitializeMint2, InitializeMintCloseAuthority,
+    },
+    token_interface::{
+        mint_to, set_authority,
+        spl_token_2022::{extension::*, instruction::AuthorityType},
+        spl_token_metadata_interface::state::TokenMetadata,
+        token_metadata_initialize, MintTo, SetAuthority, Token2022, TokenMetadataInitialize,
+    },
+};
+use spl_pod::optional_keys::OptionalNonZeroPubkey;
+
 use crate::{
-    update_account_lamports_to_minimum_balance, Manager, TokenGroup, GROUP_ACCOUNT_SEED,
-    MANAGER_SEED,
+    token_22_cpi::*, update_account_lamports_to_minimum_balance, Manager, TokenGroup,
+    GROUP_ACCOUNT_SEED, MANAGER_SEED,
 };
 
 #[derive(AnchorDeserialize, AnchorSerialize)]
@@ -40,31 +53,11 @@ pub struct CreateGroupAccount<'info> {
         space = 8 + TokenGroup::INIT_SPACE
     )]
     pub group: Account<'info, TokenGroup>,
-    #[account(
-        init,
-        signer,
-        payer = payer,
-        mint::token_program = token_program,
-        mint::decimals = 0,
-        mint::authority = authority,
-        mint::freeze_authority = manager,
-        extensions::metadata_pointer::authority = authority,
-        extensions::metadata_pointer::metadata_address = mint,
-        // group pointer authority is left as the manager so that it can be updated once token group support inside mint is added
-        extensions::group_pointer::authority = manager,
-        extensions::group_pointer::group_address = group,
-        // temporary mint close authority until a better program accounts can be used
-        extensions::close_authority::authority = manager,
-    )]
-    pub mint: Box<InterfaceAccount<'info, Mint>>,
-    #[account(
-        init,
-        payer = payer,
-        associated_token::token_program = token_program,
-        associated_token::mint = mint,
-        associated_token::authority = receiver,
-    )]
-    pub mint_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+    #[account(mut)]
+    pub mint: Signer<'info>,
+    /// CHECK: Checked and created account after mint init
+    #[account(mut)]
+    pub mint_token_account: UncheckedAccount<'info>,
     #[account(
         seeds = [MANAGER_SEED],
         bump
@@ -115,6 +108,114 @@ impl<'info> CreateGroupAccount<'info> {
 }
 
 pub fn handler(ctx: Context<CreateGroupAccount>, args: CreateGroupAccountArgs) -> Result<()> {
+    /* Expanding anchor macros */
+    let payer = &ctx.accounts.payer;
+    let authority = &ctx.accounts.authority;
+    let receiver = &ctx.accounts.receiver;
+    let group = &ctx.accounts.group;
+    let mint = &ctx.accounts.mint;
+    let manager = &ctx.accounts.manager;
+    let mint_token_account = &ctx.accounts.mint_token_account;
+
+    let system_program = &ctx.accounts.system_program;
+    let token_program = &ctx.accounts.token_program;
+    let associated_token_program = &ctx.accounts.associated_token_program;
+
+    let expected_mint_token_account =
+        get_associated_token_address_with_program_id(receiver.key, mint.key, token_program.key);
+    require_eq!(expected_mint_token_account, mint_token_account.key());
+
+    let mint_extension_types = vec![
+        ExtensionType::MintCloseAuthority,
+        ExtensionType::MetadataPointer,
+        ExtensionType::GroupPointer,
+    ];
+
+    let metadata = TokenMetadata {
+        update_authority: OptionalNonZeroPubkey::try_from(Some(authority.key())).unwrap(),
+        mint: mint.key(),
+        name: args.name.clone(),
+        symbol: args.symbol.clone(),
+        uri: args.uri.clone(),
+        additional_metadata: vec![],
+    };
+
+    let mint_size = ExtensionType::try_calculate_account_len::<Mint>(&mint_extension_types)?;
+    let metadata_size = metadata.tlv_size_of()?;
+    let rent_lamports = Rent::get()?.minimum_balance(mint_size + metadata_size);
+
+    create_account(
+        CpiContext::new(
+            system_program.to_account_info(),
+            CreateAccount {
+                from: payer.to_account_info(),
+                to: mint.to_account_info(),
+            },
+        ),
+        rent_lamports,
+        u64::try_from(mint_size).unwrap(),
+        token_program.key,
+    )?;
+
+    // temporary mint close authority until a better program accounts can be used
+    initialize_mint_close_authority(
+        CpiContext::new(
+            token_program.to_account_info(),
+            InitializeMintCloseAuthority {
+                mint: mint.to_account_info(),
+            },
+        ),
+        Some(&manager.key()),
+    )?;
+
+    initialize_metadata_pointer(
+        CpiContext::new(
+            token_program.to_account_info(),
+            InitializeMetadataPointer {
+                mint: mint.to_account_info(),
+            },
+        ),
+        Some(authority.key()),
+        Some(mint.key()),
+    )?;
+
+    // group pointer authority is left as the manager so that it can be updated once token group support inside mint is added
+    initialize_group_pointer(
+        CpiContext::new(
+            token_program.to_account_info(),
+            InitializeGroupPointer {
+                mint: mint.to_account_info(),
+            },
+        ),
+        Some(manager.key()),
+        Some(group.key()),
+    )?;
+
+    initialize_mint2(
+        CpiContext::new(
+            token_program.to_account_info(),
+            InitializeMint2 {
+                mint: mint.to_account_info(),
+            },
+        ),
+        0,
+        &authority.key(),
+        Some(&manager.key()),
+    )?;
+
+    create_associated_token(CpiContext::new(
+        associated_token_program.to_account_info(),
+        CreateAssociatedToken {
+            payer: payer.to_account_info(),
+            associated_token: mint_token_account.to_account_info(),
+            authority: receiver.to_account_info(),
+            mint: mint.to_account_info(),
+            system_program: system_program.to_account_info(),
+            token_program: token_program.to_account_info(),
+        },
+    ))?;
+    /* */
+
     // initialize token metadata
     ctx.accounts
         .initialize_metadata(args.name, args.symbol, args.uri)?;
@@ -141,3 +242,29 @@ pub fn handler(ctx: Context<CreateGroupAccount>, args: CreateGroupAccountArgs) -
 
     Ok(())
 }
+
+// #[account(
+//     init,
+//     signer,
+//     payer = payer,
+//     mint::token_program = token_program,
+//     mint::decimals = 0,
+//     mint::authority = authority,
+//     mint::freeze_authority = manager,
+//     extensions::metadata_pointer::authority = authority,
+//     extensions::metadata_pointer::metadata_address = mint,
+// group pointer authority is left as the manager so that it can be updated once token group support inside mint is added
+//     extensions::group_pointer::authority = manager,
+//     extensions::group_pointer::group_address = group,
+// temporary mint close authority until a better program accounts can be used
+//     extensions::close_authority::authority = manager,
+// )]
+// pub mint: Box<InterfaceAccount<'info, Mint>>,
+// #[account(
+//     init,
+//     payer = payer,
+//     associated_token::token_program = token_program,
+//     associated_token::mint = mint,
+//     associated_token::authority = receiver,
+// )]
+// pub mint_token_account: Box<InterfaceAccount<'info, TokenAccount>>,

--- a/programs/wen_new_standard/src/lib.rs
+++ b/programs/wen_new_standard/src/lib.rs
@@ -5,11 +5,13 @@ use anchor_lang::prelude::*;
 pub mod errors;
 pub mod instructions;
 pub mod state;
+pub mod token_22_cpi;
 pub mod utils;
 
 pub use errors::*;
 pub use instructions::*;
 pub use state::*;
+pub use token_22_cpi::*;
 pub use utils::*;
 
 declare_id!("wns1gDLt8fgLcGhWi5MqAqgXpwEP1JftKE9eZnXS1HM");

--- a/programs/wen_new_standard/src/token_22_cpi.rs
+++ b/programs/wen_new_standard/src/token_22_cpi.rs
@@ -1,0 +1,264 @@
+use anchor_lang::{prelude::*, solana_program};
+use anchor_spl::token_interface::{
+    spl_token_2022::{
+        extension::*,
+        instruction::{initialize_permanent_delegate as init_permanent_delegate, *},
+    },
+    spl_token_metadata_interface::{instruction::*, state::Field},
+};
+
+#[derive(Accounts)]
+pub struct InitializePermanentDelegate<'info> {
+    /// CHECK: CPI Account
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn initialize_permanent_delegate<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializePermanentDelegate<'info>>,
+    delegate: &Pubkey,
+) -> Result<()> {
+    let ix = init_permanent_delegate(ctx.program.key, ctx.accounts.mint.key, delegate)?;
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct InitializeTransferHook<'info> {
+    /// CHECK: CPI Account
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn initialize_transfer_hook<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeTransferHook<'info>>,
+    authority: Option<Pubkey>,
+) -> Result<()> {
+    let ix = transfer_hook::instruction::initialize(
+        &ctx.program.key,
+        &ctx.accounts.mint.key,
+        authority,
+        Some(crate::id()),
+    )?;
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct InitializeMintNonTransferrable<'info> {
+    /// CHECK: CPI Account
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn initialize_mint_non_transferable<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeMintNonTransferrable<'info>>,
+) -> Result<()> {
+    let ix = initialize_non_transferable_mint(ctx.program.key, ctx.accounts.mint.key)?;
+
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct InitializeInterestBearingMint<'info> {
+    /// CHECK: CPI Account
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn initialize_interest_bearing_mint<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeInterestBearingMint<'info>>,
+    rate_authority: Option<Pubkey>,
+    rate: i16,
+) -> Result<()> {
+    let ix = interest_bearing_mint::instruction::initialize(
+        ctx.program.key,
+        ctx.accounts.mint.key,
+        rate_authority,
+        rate,
+    )?;
+
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct InitializeMetadataPointer<'info> {
+    /// CHECK: CPI Account
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn initialize_metadata_pointer<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeMetadataPointer<'info>>,
+    authority: Option<Pubkey>,
+    metadata_address: Option<Pubkey>,
+) -> Result<()> {
+    let ix = metadata_pointer::instruction::initialize(
+        ctx.program.key,
+        ctx.accounts.mint.key,
+        authority,
+        metadata_address,
+    )?;
+
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct InitializeGroupPointer<'info> {
+    /// CHECK: CPI Account
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn initialize_group_pointer<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeGroupPointer<'info>>,
+    authority: Option<Pubkey>,
+    group_address: Option<Pubkey>,
+) -> Result<()> {
+    let ix = group_pointer::instruction::initialize(
+        ctx.program.key,
+        ctx.accounts.mint.key,
+        authority,
+        group_address,
+    )?;
+
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct InitializeGroupMemberPointer<'info> {
+    /// CHECK: CPI Account
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn initialize_group_member_pointer<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeGroupMemberPointer<'info>>,
+    authority: Option<Pubkey>,
+    member_address: Option<Pubkey>,
+) -> Result<()> {
+    let ix = group_member_pointer::instruction::initialize(
+        ctx.program.key,
+        ctx.accounts.mint.key,
+        authority,
+        member_address,
+    )?;
+
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct InitializeTransferFeeConfig<'info> {
+    /// CHECK: CPI Account
+    pub mint: AccountInfo<'info>,
+}
+
+pub fn initialize_transfer_fee_config<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeTransferFeeConfig<'info>>,
+    transfer_fee_config_authority: Option<&Pubkey>,
+    withdraw_withheld_authority: Option<&Pubkey>,
+    transfer_fee_basis_points: u16,
+    maximum_fee: u64,
+) -> Result<()> {
+    let ix = transfer_fee::instruction::initialize_transfer_fee_config(
+        ctx.program.key,
+        ctx.accounts.mint.key,
+        transfer_fee_config_authority,
+        withdraw_withheld_authority,
+        transfer_fee_basis_points,
+        maximum_fee,
+    )?;
+
+    solana_program::program::invoke(&ix, &[ctx.accounts.mint]).map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct InitializeMetadata<'info> {
+    /// CHECK: CPI Account
+    pub metadata: AccountInfo<'info>,
+    /// CHECK: CPI Account
+    pub update_authority: AccountInfo<'info>,
+    /// CHECK: CPI Account
+    pub mint: AccountInfo<'info>,
+    /// CHECK: CPI Account
+    pub mint_authority: AccountInfo<'info>,
+}
+
+pub fn intialize_metadata<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, InitializeMetadata<'info>>,
+    name: String,
+    symbol: String,
+    uri: String,
+) -> Result<()> {
+    let ix = spl_token_metadata_interface::instruction::initialize(
+        ctx.program.key,
+        ctx.accounts.metadata.key,
+        ctx.accounts.update_authority.key,
+        ctx.accounts.mint.key,
+        ctx.accounts.mint_authority.key,
+        name,
+        symbol,
+        uri,
+    );
+
+    solana_program::program::invoke_signed(
+        &ix,
+        &[
+            ctx.accounts.metadata,
+            ctx.accounts.update_authority,
+            ctx.accounts.mint,
+            ctx.accounts.mint_authority,
+        ],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct UpdateMetadataField<'info> {
+    /// CHECK: CPI Account
+    pub metadata: AccountInfo<'info>,
+    /// CHECK: CPI Account
+    pub update_authority: AccountInfo<'info>,
+}
+
+pub fn update_metadata_field<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, UpdateMetadataField<'info>>,
+    field: String,
+    value: String,
+) -> Result<()> {
+    let ix = update_field(
+        ctx.program.key,
+        ctx.accounts.metadata.key,
+        ctx.accounts.update_authority.key,
+        Field::Key(field),
+        value,
+    );
+
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.metadata, ctx.accounts.update_authority],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}
+
+#[derive(Accounts)]
+pub struct RemoveMetadataField<'info> {
+    /// CHECK: CPI Account
+    pub metadata: AccountInfo<'info>,
+    /// CHECK: CPI Account
+    pub update_authority: AccountInfo<'info>,
+}
+
+pub fn remove_metadata_field<'info>(
+    ctx: CpiContext<'_, '_, '_, 'info, RemoveMetadataField<'info>>,
+    key: String,
+    idempotent: bool,
+) -> Result<()> {
+    let ix = spl_token_metadata_interface::instruction::remove_key(
+        ctx.program.key,
+        ctx.accounts.metadata.key,
+        ctx.accounts.update_authority.key,
+        key,
+        idempotent,
+    );
+
+    solana_program::program::invoke_signed(
+        &ix,
+        &[ctx.accounts.metadata, ctx.accounts.update_authority],
+        ctx.signer_seeds,
+    )
+    .map_err(Into::into)
+}


### PR DESCRIPTION
These two instructions were bloating Solana stack offsets due to many extensions. Hence the only temporary solution is to convert those extension attributes to manual code (converting the bloat from a limited Stack size to a bit more free Compute Units)  

Closes #56 