### PR TITLE
Step 1 for bump field set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ wen_new_standard = { path = "programs/wen_new_standard", features = [
 wen_royalty_distribution = { path = "programs/wen_royalty_distribution", features = [
   "cpi",
 ] }
+spl-transfer-hook-interface = "0.5.1"
+spl-tlv-account-resolution = "0.4.0"
 
 [profile.release]
 overflow-checks = true

--- a/programs/wen_new_standard/Cargo.toml
+++ b/programs/wen_new_standard/Cargo.toml
@@ -26,13 +26,8 @@ idl-build = [
 ]
 
 [dependencies]
-anchor-lang = { version = "0.30.0", features = [
-  "init-if-needed",
-  "interface-instructions",
-] }
-anchor-spl = "0.30.0"
-spl-transfer-hook-interface = { version = "0.5.0" }
-spl-tlv-account-resolution = "0.4.0"
-wen_royalty_distribution = { path = "../wen_royalty_distribution", features = [
-  "cpi",
-] }
+anchor-lang.workspace = true
+anchor-spl.workspace = true
+wen_royalty_distribution.workspace = true
+spl-transfer-hook-interface.workspace = true
+spl-tlv-account-resolution.workspace = true

--- a/programs/wen_new_standard/src/instructions/mod.rs
+++ b/programs/wen_new_standard/src/instructions/mod.rs
@@ -1,9 +1,11 @@
 pub mod group;
 pub mod manager;
 pub mod mint;
+pub mod resize;
 pub mod royalty;
 
 pub use group::*;
 pub use manager::*;
 pub use mint::*;
+pub use resize::*;
 pub use royalty::*;

--- a/programs/wen_new_standard/src/instructions/resize/approve.rs
+++ b/programs/wen_new_standard/src/instructions/resize/approve.rs
@@ -17,6 +17,5 @@ pub struct ResizeApprove<'info> {
 }
 
 pub fn handler(_: Context<ResizeApprove>) -> Result<()> {
-    msg!("Resize complete!");
     Ok(())
 }

--- a/programs/wen_new_standard/src/instructions/resize/approve.rs
+++ b/programs/wen_new_standard/src/instructions/resize/approve.rs
@@ -1,0 +1,22 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct ResizeApprove<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        realloc = 8 + ApproveAccount::INIT_SPACE + 1,
+        realloc::payer = payer,
+        realloc::zero = false,
+    )]
+    pub approve_account: Account<'info, ApproveAccount>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(_: Context<ResizeApprove>) -> Result<()> {
+    msg!("Resize complete!");
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/resize/group.rs
+++ b/programs/wen_new_standard/src/instructions/resize/group.rs
@@ -1,0 +1,24 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct ResizeGroup<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        realloc = 8 + TokenGroup::INIT_SPACE + 1,
+        realloc::payer = payer,
+        realloc::zero = false,
+        seeds = [GROUP_ACCOUNT_SEED, group.mint.as_ref()],
+        bump,
+    )]
+    pub group: Account<'info, TokenGroup>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(_: Context<ResizeGroup>) -> Result<()> {
+    msg!("Resize complete!");
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/resize/group.rs
+++ b/programs/wen_new_standard/src/instructions/resize/group.rs
@@ -19,6 +19,5 @@ pub struct ResizeGroup<'info> {
 }
 
 pub fn handler(_: Context<ResizeGroup>) -> Result<()> {
-    msg!("Resize complete!");
     Ok(())
 }

--- a/programs/wen_new_standard/src/instructions/resize/group_member.rs
+++ b/programs/wen_new_standard/src/instructions/resize/group_member.rs
@@ -1,0 +1,24 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct ResizeGroupMember<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        realloc = 8 + TokenGroupMember::INIT_SPACE + 1,
+        realloc::payer = payer,
+        realloc::zero = false,
+        seeds = [MEMBER_ACCOUNT_SEED, member.mint.as_ref()],
+        bump,
+    )]
+    pub member: Account<'info, TokenGroupMember>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(_: Context<ResizeGroupMember>) -> Result<()> {
+    msg!("Resize complete!");
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/resize/group_member.rs
+++ b/programs/wen_new_standard/src/instructions/resize/group_member.rs
@@ -19,6 +19,5 @@ pub struct ResizeGroupMember<'info> {
 }
 
 pub fn handler(_: Context<ResizeGroupMember>) -> Result<()> {
-    msg!("Resize complete!");
     Ok(())
 }

--- a/programs/wen_new_standard/src/instructions/resize/manager.rs
+++ b/programs/wen_new_standard/src/instructions/resize/manager.rs
@@ -19,6 +19,5 @@ pub struct ResizeManager<'info> {
 }
 
 pub fn handler(_: Context<ResizeManager>) -> Result<()> {
-    msg!("Resize complete!");
     Ok(())
 }

--- a/programs/wen_new_standard/src/instructions/resize/manager.rs
+++ b/programs/wen_new_standard/src/instructions/resize/manager.rs
@@ -1,0 +1,24 @@
+use anchor_lang::prelude::*;
+
+use crate::state::*;
+
+#[derive(Accounts)]
+pub struct ResizeManager<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        realloc = 8 + Manager::INIT_SPACE + 1,
+        realloc::payer = payer,
+        realloc::zero = false,
+        seeds = [MANAGER_SEED],
+        bump,
+    )]
+    pub manager: Account<'info, Manager>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(_: Context<ResizeManager>) -> Result<()> {
+    msg!("Resize complete!");
+    Ok(())
+}

--- a/programs/wen_new_standard/src/instructions/resize/mod.rs
+++ b/programs/wen_new_standard/src/instructions/resize/mod.rs
@@ -1,0 +1,9 @@
+pub mod approve;
+pub mod group;
+pub mod group_member;
+pub mod manager;
+
+pub use approve::*;
+pub use group::*;
+pub use group_member::*;
+pub use manager::*;

--- a/programs/wen_new_standard/src/lib.rs
+++ b/programs/wen_new_standard/src/lib.rs
@@ -109,4 +109,25 @@ pub mod wen_new_standard {
     pub fn approve_transfer(ctx: Context<ApproveTransfer>, buy_amount: u64) -> Result<()> {
         instructions::royalty::approve::handler(ctx, buy_amount)
     }
+
+    /* Resize instructions */
+    pub fn resize_manager(ctx: Context<ResizeManager>) -> Result<()> {
+        instructions::resize::manager::handler(ctx)
+    }
+
+    pub fn resize_group(ctx: Context<ResizeGroup>) -> Result<()> {
+        instructions::resize::group::handler(ctx)
+    }
+
+    pub fn resize_group_member(ctx: Context<ResizeGroupMember>) -> Result<()> {
+        instructions::resize::group_member::handler(ctx)
+    }
+
+    pub fn resize_approve(ctx: Context<ResizeApprove>) -> Result<()> {
+        instructions::resize::approve::handler(ctx)
+    }
+    /**/
+
+    /* Assign bump instructions (upcoming) */
+    /**/
 }

--- a/programs/wen_royalty_distribution/Cargo.toml
+++ b/programs/wen_royalty_distribution/Cargo.toml
@@ -20,7 +20,7 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 
 [dependencies]
-anchor-lang = { version = "0.30.0", features = ["init-if-needed"] }
-anchor-spl = "0.30.0"
-spl-transfer-hook-interface = { version = "0.5.0" }
-spl-tlv-account-resolution = "0.4.0"
+anchor-lang = { workspace = true, features = ["init-if-needed"] }
+anchor-spl.workspace = true
+spl-transfer-hook-interface.workspace = true
+spl-tlv-account-resolution.workspace = true

--- a/programs/wen_royalty_distribution/src/instructions/mod.rs
+++ b/programs/wen_royalty_distribution/src/instructions/mod.rs
@@ -2,8 +2,10 @@
 
 pub mod claim;
 pub mod initialize;
+pub mod resize;
 pub mod update;
 
 pub use claim::*;
 pub use initialize::*;
+pub use resize::*;
 pub use update::*;

--- a/programs/wen_royalty_distribution/src/instructions/resize.rs
+++ b/programs/wen_royalty_distribution/src/instructions/resize.rs
@@ -24,6 +24,11 @@ pub fn handler(ctx: Context<ResizeDistribution>) -> Result<()> {
     let new_length = 8 + DistributionAccount::INIT_SPACE + 1;
     let rent_required = Rent::get()?.minimum_balance(new_length);
 
+    // Account already resized if data_len == new_length
+    if distribution_account.data_len() == new_length {
+        return Ok(());
+    }
+
     transfer(
         CpiContext::new(
             ctx.accounts.system_program.to_account_info(),
@@ -36,7 +41,5 @@ pub fn handler(ctx: Context<ResizeDistribution>) -> Result<()> {
     )?;
 
     distribution_account.realloc(new_length, false)?;
-
-    msg!("Resize complete!");
     Ok(())
 }

--- a/programs/wen_royalty_distribution/src/instructions/resize.rs
+++ b/programs/wen_royalty_distribution/src/instructions/resize.rs
@@ -1,0 +1,42 @@
+use crate::DistributionAccount;
+use anchor_lang::{
+    prelude::*,
+    system_program::{transfer, Transfer},
+};
+
+#[derive(Accounts)]
+pub struct ResizeDistribution<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(
+        mut,
+        constraint = !distribution_account.data_is_empty()
+    )]
+    /// CHECK: Owner check is done, only state account in this program
+    pub distribution_account: UncheckedAccount<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(ctx: Context<ResizeDistribution>) -> Result<()> {
+    let distribution_account = &ctx.accounts.distribution_account;
+    require_eq!(distribution_account.owner.key(), crate::id());
+
+    let new_length = 8 + DistributionAccount::INIT_SPACE + 1;
+    let rent_required = Rent::get()?.minimum_balance(new_length);
+
+    transfer(
+        CpiContext::new(
+            ctx.accounts.system_program.to_account_info(),
+            Transfer {
+                from: ctx.accounts.payer.to_account_info(),
+                to: ctx.accounts.distribution_account.to_account_info(),
+            },
+        ),
+        rent_required,
+    )?;
+
+    distribution_account.realloc(new_length, false)?;
+
+    msg!("Resize complete!");
+    Ok(())
+}

--- a/programs/wen_royalty_distribution/src/lib.rs
+++ b/programs/wen_royalty_distribution/src/lib.rs
@@ -37,4 +37,9 @@ pub mod wen_royalty_distribution {
     pub fn claim_distribution(ctx: Context<ClaimDistribution>) -> Result<()> {
         instructions::claim::handler(ctx)
     }
+
+    /// Resize old accounts for backwards compatibility.
+    pub fn resize_distribution(ctx: Context<ResizeDistribution>) -> Result<()> {
+        instructions::resize::handler(ctx)
+    }
 }

--- a/programs/wen_wns_marketplace/Cargo.toml
+++ b/programs/wen_wns_marketplace/Cargo.toml
@@ -26,4 +26,4 @@ anchor-lang.workspace = true
 anchor-spl.workspace = true
 wen_new_standard.workspace = true
 wen_royalty_distribution.workspace = true
-spl-transfer-hook-interface = "^0.5.1"
+spl-transfer-hook-interface.workspace = true


### PR DESCRIPTION
This step has the instructions to expand the account size by 1 byte (some accounts are more than that to ensure they are up to the current account's space + 1 byte). 

There will be another PR, which has the actual bump set field. 

The reason for 2 PRs is because, we cannot set any additional fields without increasing the account's space, but at the same time, anchor will cause IDL issues when deserializing old accounts. Hence, we ensure all the accounts have enough account space/rent to support the additional field by deploying the code present in this PR, and the upcoming one will refer toward the account without any IDL issues by redeploying again. 

I've ran a simulation over localnet by cloning almost 250 accounts (150 on WNS and 100 on Distribution) from mainnet and they all seem to work as expected.

Once the bump field has been set, both PRs (this and the upcoming Step 2) and the issue can be closed, as these instructions weren't made for staying permanently.