### PR TITLE
feat: complete implementing remove mint from group

### DIFF
--- a/programs/wen_new_standard/src/errors.rs
+++ b/programs/wen_new_standard/src/errors.rs
@@ -26,4 +26,6 @@ pub enum MintErrors {
     InvalidFreezeAuthority,
     #[msg("Invalid delegate authority.")]
     InvalidDelegateAuthority,
+    #[msg("Invalid Token group member mint")]
+    InvalidTokenGroupMemberMint,
 }

--- a/programs/wen_new_standard/src/instructions/mint/group/mod.rs
+++ b/programs/wen_new_standard/src/instructions/mint/group/mod.rs
@@ -1,3 +1,5 @@
 pub mod add;
+pub mod remove;
 
 pub use add::*;
+pub use remove::*;

--- a/programs/wen_new_standard/src/lib.rs
+++ b/programs/wen_new_standard/src/lib.rs
@@ -57,6 +57,11 @@ pub mod wen_new_standard {
         instructions::mint::group::add::handler(ctx)
     }
 
+    /// remove mint from group
+    pub fn remove_mint_from_group(ctx: Context<RemoveGroup>) -> Result<()> {
+        instructions::mint::group::remove::handler(ctx)
+    }
+
     /// add royalties to mint
     pub fn add_royalties(ctx: Context<AddRoyalties>, args: UpdateRoyaltiesArgs) -> Result<()> {
         instructions::mint::royalties::add::handler(ctx, args)


### PR DESCRIPTION
This PR is for removing TokenGroupMember accounts from a group PDA, and pointing the GroupMemberPointer to None indicating it's no more a part of a collection. Same structure as `AddGroup` is maintained. Tests are added with the respective instruction as well. 

Closes #68 